### PR TITLE
Fix server detail page params

### DIFF
--- a/app/(main)/settings/server/[serverName]/page.tsx
+++ b/app/(main)/settings/server/[serverName]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { ArrowLeftIcon } from '@phosphor-icons/react/dist/ssr';
 import { mcp_management, server_management } from '@/app/services/api';
@@ -17,7 +17,7 @@ import { useSocket } from '@/app/hooks/useSocket';
 
 export default function ServerDetailPage({ params }: ServerDetailPageProps) {
   const router = useRouter();
-  const resolvedParams = React.use(params);
+  const resolvedParams = params;
   const [toggleEdit, setToggleEdit] = useState(false);
   const [editedComment, setEditedComment] = useState('');
   const { clients } = useSocket();

--- a/app/types/server.ts
+++ b/app/types/server.ts
@@ -6,7 +6,7 @@ export interface SaveServerForm {
 }
 
 export interface ServerDetailPageProps {
-  params: Promise<{ serverName: string }>;
+  params: { serverName: string };
 }
 
 export interface ServerHeaderProps {


### PR DESCRIPTION
## Summary
- adjust params type for server detail page
- simplify client usage of server detail params

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856120c79e4832e98116127c751ce57