### PR TITLE
Add basic Jest setup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "next start",
     "lint": "next lint --fix",
     "prepare": "husky install",
-    "clean": "rm -rf package-lock.json ./next ./node_modules && npm install"
+    "clean": "rm -rf package-lock.json ./next ./node_modules && npm install",
+    "test": "jest"
   },
   "dependencies": {
     "@azure/app-configuration": "^1.9.0",
@@ -72,7 +73,9 @@
     "ts-node": "^10.9.2",
     "tsx": "^4.19.4",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.33.0"
+    "typescript-eslint": "^8.33.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -1,0 +1,29 @@
+import { getOracleConnection } from '../app/lib/db/connection';
+
+jest.mock('oracledb', () => ({}), { virtual: true });
+
+describe('getOracleConnection', () => {
+  const originalEnv = {
+    user: process.env.ORACLE_USER,
+    password: process.env.ORACLE_PASSWORD,
+    connectString: process.env.ORACLE_CONNECT_STRING,
+  };
+
+  beforeAll(() => {
+    delete process.env.ORACLE_USER;
+    delete process.env.ORACLE_PASSWORD;
+    delete process.env.ORACLE_CONNECT_STRING;
+  });
+
+  afterAll(() => {
+    if (originalEnv.user) process.env.ORACLE_USER = originalEnv.user;
+    if (originalEnv.password) process.env.ORACLE_PASSWORD = originalEnv.password;
+    if (originalEnv.connectString) process.env.ORACLE_CONNECT_STRING = originalEnv.connectString;
+  });
+
+  it('throws error when env vars are missing', async () => {
+    await expect(getOracleConnection()).rejects.toThrow(
+      'ORACLE_USER, ORACLE_PASSWORD, ORACLE_CONNECT_STRING 환경변수가 모두 설정되어야 합니다.'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest dev dependencies and test script
- configure Jest for TypeScript
- add failing test for missing Oracle env variables

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856120fd26c832eb1b3e5b6eaa80a7a