### PR TITLE
Refactor type definitions

### DIFF
--- a/app/(main)/chat/components/ChatInputSection/index.tsx
+++ b/app/(main)/chat/components/ChatInputSection/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useRef, useEffect } from 'react';
-import type { ChatInputProps, serverStatusType } from '@/app/types';
+import type { ChatInputProps, ServerStatus } from '@/app/types';
 import { useQuery } from '@tanstack/react-query';
 import {
   aiModel_management,
@@ -27,7 +27,7 @@ export default function ChatInputSection({
   const [boxHeight, setBoxHeight] = useState(1);
   const [isMcpSettingsOpen, setIsMcpSettingsOpen] = useState(false);
   const [serverStatuses, setServerStatuses] = useState<
-    Record<string, serverStatusType>
+    Record<string, ServerStatus>
   >({});
   const { clients, mcpResponse } = useSocket();
 

--- a/app/(main)/chat/page.tsx
+++ b/app/(main)/chat/page.tsx
@@ -10,7 +10,7 @@ import {
 } from '@tanstack/react-query';
 import {
   AIChatRes,
-  AIReqState,
+  AIRequestState,
   ChatReq,
   MessagesResponse,
   SaveChatRes,
@@ -32,7 +32,7 @@ import { useSocket } from '@/app/hooks/useSocket';
 
 export default function Chat() {
   const [isMounted, setIsMounted] = useState(false);
-  const [reqState, setReqState] = useState<AIReqState>(initReqState);
+  const [reqState, setReqState] = useState<AIRequestState>(initReqState);
   const isUserLoading = useUserStore((state) => state.isLoading);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const queryClient = useQueryClient();

--- a/app/(main)/components/dashboard/components/AgentStatusSection.tsx
+++ b/app/(main)/components/dashboard/components/AgentStatusSection.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Link from 'next/link';
 import StatusPing from '../../../settings/components/StatusPing';
-import { AgentStatusSectionProps } from '@/app/types/dashboard';
+import { AgentStatusSectionProps } from '@/app/types';
 import { XIcon } from '@phosphor-icons/react/dist/ssr';
 
 export default function AgentStatusSection({

--- a/app/(main)/components/dashboard/components/CustomFlowEdge.tsx
+++ b/app/(main)/components/dashboard/components/CustomFlowEdge.tsx
@@ -7,10 +7,10 @@ import {
   type Edge,
 } from '@xyflow/react';
 import { Icon } from '@phosphor-icons/react';
-import { serverStatusType } from '@/app/types';
+import { ServerStatus } from '@/app/types';
 
 const CustomFlowEdge: FC<
-  EdgeProps<Edge<{ icon?: Icon; label?: serverStatusType }>>
+  EdgeProps<Edge<{ icon?: Icon; label?: ServerStatus }>>
 > = ({
   id,
   sourceX,

--- a/app/(main)/components/dashboard/components/CustomFlowNode.tsx
+++ b/app/(main)/components/dashboard/components/CustomFlowNode.tsx
@@ -2,7 +2,7 @@ import React, { memo } from 'react';
 import { Handle, Position } from '@xyflow/react';
 
 import '@/tailwind.config';
-import { FlowNodeDataType } from '@/app/types/dashboard';
+import { FlowNodeDataType } from '@/app/types';
 import StatusPing from '@/app/(main)/settings/components/StatusPing';
 
 function CustomFlowNode({ data }: { data: FlowNodeDataType }) {

--- a/app/(main)/components/dashboard/components/McpFlowSection.tsx
+++ b/app/(main)/components/dashboard/components/McpFlowSection.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { EdgeTypes, NodeTypes, ReactFlow } from '@xyflow/react';
 import CustomFlowNode from './CustomFlowNode';
-import { FlowSectionProps } from '@/app/types/dashboard';
-import { serverStatusType } from '@/app/types';
+import { FlowSectionProps } from '@/app/types';
+import { ServerStatus } from '@/app/types';
 import { initialEdges, initialNodes } from './nodeAndEede';
 import CustomFlowEdge from './CustomFlowEdge';
 import {
@@ -13,7 +13,7 @@ import {
 
 import '@xyflow/react/dist/style.css';
 
-const stateToDisplay = (serverState: serverStatusType) => {
+const stateToDisplay = (serverState: ServerStatus) => {
   switch (serverState) {
     case 'success':
       return { icon: LinkIcon, label: 'success' };
@@ -44,7 +44,7 @@ export default function McpFlowSection({
   );
 
   const nodes = initialNodes.map((node) => {
-    let state: serverStatusType = 'offline';
+    let state: ServerStatus = 'offline';
     if (node.id === 'Web Server') {
       state = 'success';
     } else if (node.id === 'DB Server') {

--- a/app/(main)/components/dashboard/components/McpLinksSection.tsx
+++ b/app/(main)/components/dashboard/components/McpLinksSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { LinkIcon } from '@phosphor-icons/react/dist/ssr';
-import { McpLinkArticle } from '@/app/types/dashboard';
+import { McpLinkArticle } from '@/app/types';
 
 const mcp_link: McpLinkArticle[] = [
   {

--- a/app/(main)/components/dashboard/components/ResponseTimeSection.tsx
+++ b/app/(main)/components/dashboard/components/ResponseTimeSection.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ResponseTimeChart from '../../ResponseTimeChart';
-import { ResponseTimeSectionProps } from '@/app/types/dashboard';
+import { ResponseTimeSectionProps } from '@/app/types';
 
 export default function ResponseTimeSection({
   data,

--- a/app/(main)/components/dashboard/components/ServerStatusCard.tsx
+++ b/app/(main)/components/dashboard/components/ServerStatusCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import StatusPing from '../../../settings/components/StatusPing';
-import { ServerStatusCardProps } from '@/app/types/dashboard';
+import { ServerStatusCardProps } from '@/app/types';
 
 export default function ServerStatusCard({
   isPending,

--- a/app/(main)/components/dashboard/components/UsageCard.tsx
+++ b/app/(main)/components/dashboard/components/UsageCard.tsx
@@ -1,4 +1,4 @@
-import { UsageCardProps } from '@/app/types/dashboard';
+import { UsageCardProps } from '@/app/types';
 import React from 'react';
 
 export default function UsageCard({ todayUsage }: UsageCardProps) {

--- a/app/(main)/components/dashboard/components/nodeAndEede.ts
+++ b/app/(main)/components/dashboard/components/nodeAndEede.ts
@@ -1,4 +1,4 @@
-import { CustomEdge, CustomNode } from '@/app/types/dashboard';
+import { CustomEdge, CustomNode } from '@/app/types';
 import {
   DatabaseIcon,
   HardDrivesIcon,

--- a/app/(main)/components/dashboard/index.tsx
+++ b/app/(main)/components/dashboard/index.tsx
@@ -6,7 +6,7 @@ import {
   server_management,
 } from '@/app/services/api';
 import { useQuery } from '@tanstack/react-query';
-import { DurationData, serverStatusType } from '@/app/types';
+import { DurationData, ServerStatus } from '@/app/types';
 import { useSocket } from '@/app/hooks/useSocket';
 import ModelInfoCard from './components/ModelInfoCard';
 import ServerStatusCard from './components/ServerStatusCard';
@@ -21,7 +21,7 @@ export default function Dashboard() {
   const { clients } = useSocket();
 
   const [serverStatuses, setServerStatuses] = useState<
-    Record<string, serverStatusType>
+    Record<string, ServerStatus>
   >({});
 
   const { isPending: isPendingServ, isSuccess: isSuccessServ } = useQuery({

--- a/app/(main)/settings/mcp_mng/components/AddMcpForm.tsx
+++ b/app/(main)/settings/mcp_mng/components/AddMcpForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { AddMcpFormProps, McpToolRes } from '@/app/types/management';
+import { AddMcpFormProps, McpToolRes } from '@/app/types';
 
 export const AddMcpForm: React.FC<AddMcpFormProps> = ({ onAdd, onCancel }) => {
   const [newTool, setNewTool] = useState<Partial<McpToolRes>>({

--- a/app/(main)/settings/mcp_mng/components/McpTable.tsx
+++ b/app/(main)/settings/mcp_mng/components/McpTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { McpTableProps } from '@/app/types/management';
+import { McpTableProps } from '@/app/types';
 
 export const McpTable: React.FC<McpTableProps> = ({
   mcpTools,

--- a/app/(main)/settings/mcp_mng/page.tsx
+++ b/app/(main)/settings/mcp_mng/page.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { mcp_management } from '@/app/services/api';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
-import { McpToolRes } from '@/app/types/management';
+import { McpToolRes } from '@/app/types';
 import { AddMcpForm } from './components/AddMcpForm';
 import { McpTable } from './components/McpTable';
 import Link from 'next/link';

--- a/app/(main)/settings/server/[serverName]/components/ServerDescription.tsx
+++ b/app/(main)/settings/server/[serverName]/components/ServerDescription.tsx
@@ -1,5 +1,5 @@
 import { ProgressCircle } from './ProgressCircle';
-import { ServerDescriptionProps } from '@/app/types/server';
+import { ServerDescriptionProps } from '@/app/types';
 
 export const ServerDescription = ({
   isLoading,

--- a/app/(main)/settings/server/[serverName]/components/ServerHeader.tsx
+++ b/app/(main)/settings/server/[serverName]/components/ServerHeader.tsx
@@ -6,7 +6,7 @@ import {
 
 import { ProgressCircle } from './ProgressCircle';
 import StatusPing from '../../../components/StatusPing';
-import { ServerHeaderProps } from '@/app/types/server';
+import { ServerHeaderProps } from '@/app/types';
 
 export const ServerHeader = ({
   serverName,

--- a/app/(main)/settings/server/[serverName]/components/ServerInfo.tsx
+++ b/app/(main)/settings/server/[serverName]/components/ServerInfo.tsx
@@ -1,4 +1,4 @@
-import { ServerInfoProps } from '@/app/types/server';
+import { ServerInfoProps } from '@/app/types';
 
 export const ServerInfo = ({
   isLoading,

--- a/app/(main)/settings/server/[serverName]/page.tsx
+++ b/app/(main)/settings/server/[serverName]/page.tsx
@@ -10,7 +10,7 @@ import { toast } from 'react-toastify';
 import { ServerHeader } from './components/ServerHeader';
 import { ServerDescription } from './components/ServerDescription';
 import { ServerInfo } from './components/ServerInfo';
-import { ServerDetailPageProps } from '@/app/types/server';
+import { ServerDetailPageProps } from '@/app/types';
 import McpTool from './components/McpTool';
 import McpToolSetting from './components/McpToolSetting';
 import { useSocket } from '@/app/hooks/useSocket';

--- a/app/(main)/settings/server/new/page.tsx
+++ b/app/(main)/settings/server/new/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { SaveServerForm } from '@/app/types/server';
+import { SaveServerForm } from '@/app/types';
 import { useMutation } from '@tanstack/react-query';
 import { server_management } from '@/app/services/api';
 import { toast } from 'react-toastify';

--- a/app/(main)/settings/servers/page.tsx
+++ b/app/(main)/settings/servers/page.tsx
@@ -6,15 +6,15 @@ import Link from 'next/link';
 import ServerList from '../components/ServerList';
 import { useSocket } from '@/app/hooks/useSocket';
 import { useEffect, useState } from 'react';
-import { pingStatusType, serverStatusType } from '@/app/types';
+import { PingStatus, ServerStatus } from '@/app/types';
 import { CaretLeftIcon } from '@phosphor-icons/react/dist/ssr';
 
 export default function Servers() {
   const [pingStatuses, setPingStatuses] = useState<
-    Record<string, pingStatusType>
+    Record<string, PingStatus>
   >({});
   const [serverStatuses, setServerStatuses] = useState<
-    Record<string, serverStatusType>
+    Record<string, ServerStatus>
   >({});
 
   const { data: servers, isSuccess: isGetServers } = useQuery({

--- a/app/(main)/settings/user_mng/components/AddUserForm.tsx
+++ b/app/(main)/settings/user_mng/components/AddUserForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { AddUserFormProps } from '@/app/types/management';
+import { AddUserFormProps } from '@/app/types';
 import { UserListRes } from '@/app/types';
 
 export const AddUserForm: React.FC<AddUserFormProps> = ({

--- a/app/(main)/settings/user_mng/components/UserTable.tsx
+++ b/app/(main)/settings/user_mng/components/UserTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { UserTableProps } from '@/app/types/management';
+import { UserTableProps } from '@/app/types';
 
 export const UserTable: React.FC<UserTableProps> = ({
   users,

--- a/app/api/mcp/update-mcp-tools/route.ts
+++ b/app/api/mcp/update-mcp-tools/route.ts
@@ -1,5 +1,5 @@
 import { mcp_query_management } from '@/app/lib/db/queries';
-import { McpToolRes } from '@/app/types/management';
+import { McpToolRes } from '@/app/types';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function PUT(request: NextRequest) {

--- a/app/hooks/useSocket.ts
+++ b/app/hooks/useSocket.ts
@@ -1,13 +1,13 @@
 import { useState, useEffect } from 'react';
 import io from 'socket.io-client';
-import { ClientInfo } from '@/app/types/socket';
-import { McpParamsRes, pingStatusType, SaveChatRes } from '../types';
+import { ClientInfo } from '@/app/types';
+import { McpParamsRes, PingStatus, SaveChatRes } from '../types';
 
 export const useSocket = (serverName?: string) => {
   const [socketInstance, setSocketInstance] = useState<ReturnType<
     typeof io
   > | null>(null);
-  const [pingStatus, setPingStatus] = useState<pingStatusType>('idle');
+  const [pingStatus, setPingStatus] = useState<PingStatus>('idle');
   const [clients, setClients] = useState<ClientInfo[]>([]);
   const [messageStatus, setMessageStatus] = useState<
     'idle' | 'sending' | 'success' | 'error'

--- a/app/lib/db/queries.ts
+++ b/app/lib/db/queries.ts
@@ -1,7 +1,7 @@
 import { getOracleConnection } from '@/app/lib/db/connection';
 import oracledb from 'oracledb';
 import { DurationData, UserListRes } from '@/app/types';
-import { McpToolRes } from '@/app/types/management';
+import { McpToolRes } from '@/app/types';
 import { McpParamsRes } from '@/app/types/api';
 
 // 메시지 관리 관련 쿼리

--- a/app/types/components.ts
+++ b/app/types/components.ts
@@ -5,8 +5,8 @@ import { McpRes, ServerRes, McpParamsRes } from './api';
 
 export interface ChatMessageProps {
   message: Message;
-  reqState: AIReqState;
-  setReqState: React.Dispatch<React.SetStateAction<AIReqState>>;
+  reqState: AIRequestState;
+  setReqState: React.Dispatch<React.SetStateAction<AIRequestState>>;
 }
 
 export interface ChatInputProps {
@@ -27,8 +27,8 @@ export interface MessageListProps {
   messages: Message[];
   userId?: string;
   messagesEndRef: React.RefObject<HTMLDivElement | null>;
-  reqState: AIReqState;
-  setReqState: React.Dispatch<React.SetStateAction<AIReqState>>;
+  reqState: AIRequestState;
+  setReqState: React.Dispatch<React.SetStateAction<AIRequestState>>;
   lastMessageRef: (node: HTMLDivElement) => void;
 }
 
@@ -37,24 +37,24 @@ export interface AIResponseChatProps {
   CREATED_AT: Date;
 }
 
-export interface AIReqState {
+export interface AIRequestState {
   messageId: number;
   isAIRes: boolean;
   isAIResSave: boolean;
 }
 
-export type serverStatusType = 'offline' | 'loading' | 'success';
-export type pingStatusType = 'idle' | 'loading' | 'success';
+export type ServerStatus = 'offline' | 'loading' | 'success';
+export type PingStatus = 'idle' | 'loading' | 'success';
 export interface StatusPingProps {
-  status: serverStatusType;
+  status: ServerStatus;
   size?: number;
 }
 
 export interface ServerCardProps {
   serverName: string;
-  serverStatus: serverStatusType;
+  serverStatus: ServerStatus;
   client?: ClientInfo;
-  pingStatus: pingStatusType;
+  pingStatus: PingStatus;
   onTestPing: (serverName: string) => void;
 }
 
@@ -65,15 +65,15 @@ export interface ServerCardSkeletonProps {
 export interface ServerCardWrapperProps {
   serverName: string;
   onTestPing: (serverName: string) => void;
-  pingStatus: pingStatusType;
+  pingStatus: PingStatus;
 }
 
 export interface ServerListProps {
   clients: ClientInfo[];
   servers: ServerRes[];
   isGetServers: boolean;
-  serverStatuses: Record<string, serverStatusType>;
-  pingStatuses: Record<string, pingStatusType>;
+  serverStatuses: Record<string, ServerStatus>;
+  pingStatuses: Record<string, PingStatus>;
   handleTestPing: (serverName: string) => void;
 }
 
@@ -96,7 +96,7 @@ export interface McpSettingsModalProps {
   onServerSelect: (serverId: string) => void;
   onClearSelection: () => void;
   servers: ServerRes[] | undefined;
-  serverStatuses: Record<string, serverStatusType>;
+  serverStatuses: Record<string, ServerStatus>;
   mcps: McpRes[] | undefined;
   isMcpParamsPending: boolean;
 }

--- a/app/types/dashboard.ts
+++ b/app/types/dashboard.ts
@@ -1,6 +1,6 @@
 import { Icon } from '@phosphor-icons/react';
 import { ServerRes } from './api';
-import { serverStatusType } from './components';
+import { ServerStatus } from './components';
 import { DurationData } from './message';
 import { ClientInfo } from './socket';
 import { MarkerType, Position, Node } from '@xyflow/react';
@@ -27,14 +27,14 @@ export type McpLinkArticle = { title: string; link: string };
 export interface AgentStatusSectionProps {
   clients: ClientInfo[];
   servers: ServerRes[];
-  serverStatuses: Record<string, serverStatusType>;
+  serverStatuses: Record<string, ServerStatus>;
 }
 
 export interface FlowSectionProps {
   servers: ServerRes[];
-  serverStatuses: Record<string, serverStatusType>;
-  modelStatus: serverStatusType;
-  dbStatus: serverStatusType;
+  serverStatuses: Record<string, ServerStatus>;
+  modelStatus: ServerStatus;
+  dbStatus: ServerStatus;
 }
 
 export type FlowNodeDataType = {
@@ -45,12 +45,12 @@ export type FlowNodeDataType = {
   isTargetVisible?: boolean;
   sourcePosition?: Position;
   targetPosition?: Position;
-  status?: serverStatusType;
+  status?: ServerStatus;
 };
 
 export interface CustomNode extends Node {
   data: FlowNodeDataType;
-  state: serverStatusType;
+  state: ServerStatus;
 }
 
 export type CustomEdge = {

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -2,3 +2,7 @@ export * from './message';
 export * from './components';
 export * from './api';
 export * from './store';
+export * from './dashboard';
+export * from './management';
+export * from './server';
+export * from './socket';

--- a/app/types/server.ts
+++ b/app/types/server.ts
@@ -1,4 +1,4 @@
-import { serverStatus } from './components';
+import { ServerStatus } from './components';
 
 export interface SaveServerForm {
   SERVERNAME: string;
@@ -16,7 +16,7 @@ export interface ServerHeaderProps {
   isDeleting: boolean;
   onEdit: () => void;
   onDelete: () => void;
-  status: serverStatus;
+  status: ServerStatus;
 }
 
 export interface ServerDescriptionProps {

--- a/socket/server.ts
+++ b/socket/server.ts
@@ -3,7 +3,7 @@ import { createServer } from 'http';
 import { Server } from 'socket.io';
 import type { Socket } from 'socket.io';
 import type { Request, Response } from 'express';
-import { ClientInfo, ResponseClient } from '@/app/types/socket';
+import { ClientInfo, ResponseClient } from '@/app/types';
 import { McpParamsRes } from '@/app/types';
 import { message_management } from '@/app/services/api';
 


### PR DESCRIPTION
## Summary
- rename `serverStatusType` to `ServerStatus` and `pingStatusType` to `PingStatus`
- rename `AIReqState` to `AIRequestState`
- update components to use new type names
- export all type modules from a single index
- fix imports across the project

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685611dcd80c832e8250dc8956f11468