### PR TITLE
Fix timezone handling for Oracle

### DIFF
--- a/app/lib/db/connection.ts
+++ b/app/lib/db/connection.ts
@@ -17,7 +17,14 @@ function checkEnv() {
 export async function getOracleConnection() {
   try {
     checkEnv();
+    // Ensure the Node.js process uses a consistent timezone
+    if (!process.env.TZ) {
+      process.env.TZ = 'Asia/Seoul';
+    }
+
     const connection = await oracledb.getConnection(dbConfig);
+    // Align Oracle session timezone with the Node.js timezone
+    await connection.execute("ALTER SESSION SET TIME_ZONE = 'Asia/Seoul'");
     return connection;
   } catch (err) {
     console.error('Oracle 연결 실패:', err);


### PR DESCRIPTION
## Summary
- set Asia/Seoul timezone for Node and Oracle session

## Testing
- `npm test` *(fails: jest not found)*
- `npx eslint app/lib/db/connection.ts` *(fails: cannot find `@next/eslint-plugin-next`)*

------
https://chatgpt.com/codex/tasks/task_e_6856e7528c14832e9ac160a33e6f6844