### PR TITLE
Add usage statistics card to dashboard

### DIFF
--- a/app/(main)/components/dashboard/components/McpLinksSection.tsx
+++ b/app/(main)/components/dashboard/components/McpLinksSection.tsx
@@ -26,7 +26,7 @@ const mcp_link: McpLinkArticle[] = [
 
 export default function McpLinksSection() {
   return (
-    <div className="col-span-12 row-start-5 rounded-lg bg-white p-4 shadow">
+    <div className="col-span-12 row-start-6 rounded-lg bg-white p-4 shadow">
       <h2 className="text-lg font-bold">MCP 관련 DOC & POST</h2>
       <ul className="mt-4 mb-2 list-inside list-decimal">
         {mcp_link.map((item) => (

--- a/app/(main)/components/dashboard/components/UsageCard.tsx
+++ b/app/(main)/components/dashboard/components/UsageCard.tsx
@@ -1,23 +1,26 @@
 import { UsageCardProps } from '@/app/types';
 import React, { useMemo } from 'react';
 
-export default function UsageCard({ data }: UsageCardProps) {
-  const todayUsage = useMemo(() => {
+export default function UsageCard({ data, selectedUsername }: UsageCardProps) {
+  const thisMonthUsage = useMemo(() => {
     if (!data) return 0;
     const today = new Date();
+    const currentYear = today.getFullYear();
+    const currentMonth = today.getMonth();
     return data.filter((item) => {
       const itemDate = new Date(item.CREATED_AT);
-      return (
-        itemDate.getDate() === today.getDate() &&
-        itemDate.getMonth() === today.getMonth() &&
-        itemDate.getFullYear() === today.getFullYear()
-      );
+      const isSameMonth =
+        itemDate.getFullYear() === currentYear &&
+        itemDate.getMonth() === currentMonth;
+      const isSameUser =
+        selectedUsername === 'all' || item.USERNAME === selectedUsername;
+      return isSameMonth && isSameUser;
     }).length;
-  }, [data]);
+  }, [data, selectedUsername]);
 
   return (
     <div className="flex items-center rounded-lg bg-white p-4 shadow">
-      <b>{new Date().getMonth() + 1}월 사용 횟수 : </b>&nbsp;{todayUsage}회
+      <b>{new Date().getMonth() + 1}월 사용 횟수 : </b>&nbsp;{thisMonthUsage}회
     </div>
   );
 }

--- a/app/(main)/components/dashboard/components/UsageTable.tsx
+++ b/app/(main)/components/dashboard/components/UsageTable.tsx
@@ -1,0 +1,60 @@
+import React, { useMemo } from 'react';
+import { UsageTableProps } from '@/app/types';
+
+export default function UsageTable({ data }: UsageTableProps) {
+  const usageByUser = useMemo(() => {
+    const today = new Date();
+    const currentYear = today.getFullYear();
+    const currentMonth = today.getMonth();
+    const counts = new Map<string, number>();
+
+    data.forEach((item) => {
+      const itemDate = new Date(item.CREATED_AT);
+      if (
+        itemDate.getFullYear() === currentYear &&
+        itemDate.getMonth() === currentMonth
+      ) {
+        counts.set(item.USERNAME, (counts.get(item.USERNAME) || 0) + 1);
+      }
+    });
+
+    return Array.from(counts.entries())
+      .map(([username, count]) => ({ username, count }))
+      .sort((a, b) => b.count - a.count);
+  }, [data]);
+
+  return (
+    <div className="col-span-12 row-start-5 rounded-lg bg-white p-4 shadow">
+      <h2 className="mb-2 text-lg font-bold">
+        {new Date().getMonth() + 1}월 사용자별 사용 횟수
+      </h2>
+      <table className="w-full table-auto text-sm">
+        <thead>
+          <tr>
+            <th className="border-b p-2 text-left">사용자</th>
+            <th className="border-b p-2 text-right">횟수</th>
+          </tr>
+        </thead>
+        <tbody>
+          {usageByUser.length > 0 ? (
+            usageByUser.map((item) => (
+              <tr key={item.username}>
+                <td className="border-b p-2">{item.username}</td>
+                <td className="border-b p-2 text-right">{item.count}</td>
+              </tr>
+            ))
+          ) : (
+            <tr>
+              <td
+                colSpan={2}
+                className="py-4 text-center text-gray-500"
+              >
+                데이터가 없습니다
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/(main)/components/dashboard/index.tsx
+++ b/app/(main)/components/dashboard/index.tsx
@@ -11,7 +11,7 @@ import { useSocket } from '@/app/hooks/useSocket';
 import { useSession } from 'next-auth/react';
 import ModelInfoCard from './components/ModelInfoCard';
 import ServerStatusCard from './components/ServerStatusCard';
-// import UsageCard from './components/UsageCard';
+import UsageCard from './components/UsageCard';
 import AgentStatusSection from './components/AgentStatusSection';
 import ResponseTimeSection from './components/ResponseTimeSection';
 import McpLinksSection from './components/McpLinksSection';
@@ -82,7 +82,7 @@ export default function Dashboard() {
     <div className="container mx-auto grid w-full grid-cols-12 gap-4 p-4">
       <ModelInfoCard />
       <ServerStatusCard isPending={isPendingServ} isSuccess={isSuccessServ} />
-      {/* <UsageCard todayUsage={todayUsage} /> */}
+      <UsageCard data={data || []} selectedUsername={selectedUsername} />
 
       <McpFlowSection
         servers={servers || []}

--- a/app/(main)/components/dashboard/index.tsx
+++ b/app/(main)/components/dashboard/index.tsx
@@ -12,6 +12,7 @@ import { useSession } from 'next-auth/react';
 import ModelInfoCard from './components/ModelInfoCard';
 import ServerStatusCard from './components/ServerStatusCard';
 import UsageCard from './components/UsageCard';
+import UsageTable from './components/UsageTable';
 import AgentStatusSection from './components/AgentStatusSection';
 import ResponseTimeSection from './components/ResponseTimeSection';
 import McpLinksSection from './components/McpLinksSection';
@@ -108,6 +109,8 @@ export default function Dashboard() {
         onUsernameChange={setSelectedUsername}
         isLoggedIn={!!session}
       />
+
+      <UsageTable data={data || []} />
 
       <McpLinksSection />
     </div>

--- a/app/types/dashboard.ts
+++ b/app/types/dashboard.ts
@@ -10,6 +10,10 @@ export interface UsageCardProps {
   selectedUsername: string;
 }
 
+export interface UsageTableProps {
+  data: DurationData[];
+}
+
 export interface ServerStatusCardProps {
   isPending: boolean;
   isSuccess: boolean;

--- a/app/types/dashboard.ts
+++ b/app/types/dashboard.ts
@@ -7,6 +7,7 @@ import { MarkerType, Position, Node } from '@xyflow/react';
 
 export interface UsageCardProps {
   data: DurationData[];
+  selectedUsername: string;
 }
 
 export interface ServerStatusCardProps {


### PR DESCRIPTION
## Summary
- show monthly AI usage count for selected user in dashboard

## Testing
- `npx --no-install tsc -p tsconfig.json` *(fails: cannot find modules)*
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e80889d4832ea72251c40ccf8a58