### PR TITLE
Implement chat rooms feature

### DIFF
--- a/app/(main)/chat/page.tsx
+++ b/app/(main)/chat/page.tsx
@@ -27,6 +27,7 @@ import LoadingResponse from './components/MessageList/components/LoadingResponse
 import ErrorResponse from './components/MessageList/components/ErrorResponse';
 import { initReqState } from '@/app/lib/common';
 import { useSession } from 'next-auth/react';
+import { useSearchParams } from 'next/navigation';
 import ChatInputSection from '@/app/(main)/chat/components/ChatInputSection';
 import { useSocket } from '@/app/hooks/useSocket';
 
@@ -37,6 +38,8 @@ export default function Chat() {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const queryClient = useQueryClient();
   const { data: session } = useSession();
+  const searchParams = useSearchParams();
+  const roomHash = searchParams.get('roomHash') || 'default';
   const observerRef = useRef<IntersectionObserver | null>(null);
   const { sendMessageWithMCP } = useSocket();
   const [selectServer, setSelectServer] = useState('');
@@ -52,9 +55,9 @@ export default function Chat() {
     hasNextPage,
     isFetchingNextPage,
   } = useInfiniteQuery<MessagesResponse, Error>({
-    queryKey: ['messages', userId],
+    queryKey: ['messages', userId, roomHash],
     queryFn: ({ pageParam }) =>
-      message_management.getMessages(userId!, pageParam as string),
+      message_management.getMessages(userId!, roomHash, pageParam as string),
     getNextPageParam: (lastPage) => lastPage.nextCursor,
     enabled: !!userId && isMounted,
     initialPageParam: undefined,
@@ -128,7 +131,7 @@ export default function Chat() {
   // not mcp ai 메세지용
   const handleSendMessage = async (req: ChatReq) => {
     try {
-      await saveMessageMutation.mutateAsync(req);
+      await saveMessageMutation.mutateAsync({ ...req, ROOM_HASH: roomHash });
     } catch (error) {
       console.error('메시지 전송 중 오류 발생:', error);
     }

--- a/app/api/message/create-room/route.ts
+++ b/app/api/message/create-room/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { message_query_management } from '@/app/lib/db/queries';
+import { randomUUID } from 'crypto';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { USER_ID } = await req.json();
+    if (!USER_ID) {
+      return NextResponse.json(
+        { error: 'USER_ID는 필수입니다.' },
+        { status: 400 }
+      );
+    }
+    const roomHash = randomUUID();
+    await message_query_management.createChatRoom(USER_ID, roomHash);
+    return NextResponse.json({ roomHash });
+  } catch (err) {
+    console.error('채팅방 생성 실패:', err);
+    const msg = err instanceof Error ? err.message : '채팅방 생성 실패';
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/app/api/message/get-all-dates/route.ts
+++ b/app/api/message/get-all-dates/route.ts
@@ -5,6 +5,7 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const userId = searchParams.get('userId');
+    const roomHash = searchParams.get('roomHash') || 'default';
 
     if (!userId) {
       return NextResponse.json(
@@ -13,7 +14,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const dates = await message_query_management.getMessageDates(userId);
+    const dates = await message_query_management.getMessageDates(userId, roomHash);
 
     return NextResponse.json({ dates });
   } catch (error) {

--- a/app/api/message/get-messages/route.ts
+++ b/app/api/message/get-messages/route.ts
@@ -5,6 +5,7 @@ export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
     const userId = searchParams.get('userId');
+    const roomHash = searchParams.get('roomHash') || 'default';
     const cursor = searchParams.get('cursor') || undefined;
     const limit = Number(searchParams.get('limit')) || 20;
 
@@ -16,7 +17,12 @@ export async function GET(req: NextRequest) {
     }
 
     const { messages, nextCursor } =
-      await message_query_management.getChatMessages(userId, limit, cursor);
+      await message_query_management.getChatMessages(
+        userId,
+        roomHash,
+        limit,
+        cursor
+      );
 
     console.log(messages);
 

--- a/app/api/message/get-rooms/route.ts
+++ b/app/api/message/get-rooms/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { message_query_management } from '@/app/lib/db/queries';
+
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const userId = searchParams.get('userId');
+    if (!userId) {
+      return NextResponse.json(
+        { error: '사용자 ID는 필수입니다.' },
+        { status: 400 }
+      );
+    }
+    const rooms = await message_query_management.getChatRooms(userId);
+    return NextResponse.json({ rooms });
+  } catch (err) {
+    console.error('채팅방 조회 실패:', err);
+    const msg = err instanceof Error ? err.message : '채팅방 조회 실패';
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/app/api/message/save-message/route.ts
+++ b/app/api/message/save-message/route.ts
@@ -3,7 +3,7 @@ import { message_query_management } from '@/app/lib/db/queries';
 
 export async function POST(req: NextRequest) {
   try {
-    const { USER_ID, CONTENT, MCP_SERVER } = await req.json();
+    const { USER_ID, CONTENT, ROOM_HASH, MCP_SERVER } = await req.json();
     if (!USER_ID || !CONTENT) {
       return NextResponse.json(
         { error: 'userId와 content는 필수입니다.' },
@@ -13,6 +13,7 @@ export async function POST(req: NextRequest) {
     console.log('MCP_SERVER ', MCP_SERVER);
     const result_db = await message_query_management.saveChatMessage(
       USER_ID,
+      ROOM_HASH,
       CONTENT,
       MCP_SERVER
     );
@@ -21,6 +22,7 @@ export async function POST(req: NextRequest) {
       id: result_db.id,
       CONTENT,
       USER_ID,
+      ROOM_HASH,
       MCP_SERVER: MCP_SERVER || undefined,
     });
   } catch (err) {

--- a/app/lib/db/queries.ts
+++ b/app/lib/db/queries.ts
@@ -7,17 +7,23 @@ import { McpParamsRes } from '@/app/types/api';
 // 메시지 관리 관련 쿼리
 export const message_query_management = {
   // 채팅 메시지 저장
-  async saveChatMessage(userId: string, content: string, MCP_SERVER?: string) {
+  async saveChatMessage(
+    userId: string,
+    roomHash: string,
+    content: string,
+    MCP_SERVER?: string
+  ) {
     const connection = await getOracleConnection();
     try {
-      const sql = `INSERT INTO chat_messages (user_id, content, created_at, mcp_server) 
-                   VALUES (:userId, :content, CURRENT_DATE, :mcp_server) 
+      const sql = `INSERT INTO chat_messages (user_id, room_hash, content, created_at, mcp_server)
+                   VALUES (:userId, :roomHash, :content, CURRENT_DATE, :mcp_server)
                    RETURNING id INTO :id`;
 
       const result = await connection.execute(
         sql,
         {
           userId,
+          roomHash: roomHash || 'default',
           content,
           id: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
           mcp_server: MCP_SERVER || null,
@@ -42,8 +48,41 @@ export const message_query_management = {
     }
   },
 
+  async createChatRoom(userId: string, roomHash: string) {
+    const connection = await getOracleConnection();
+    try {
+      await connection.execute(
+        `INSERT INTO chat_rooms (room_hash, user_id, created_at) VALUES (:roomHash, :userId, CURRENT_DATE)`,
+        { roomHash, userId },
+        { autoCommit: true }
+      );
+      return { roomHash };
+    } finally {
+      await connection.close();
+    }
+  },
+
+  async getChatRooms(userId: string) {
+    const connection = await getOracleConnection();
+    try {
+      const result = await connection.execute(
+        `SELECT ROOM_HASH, USER_ID, CREATED_AT FROM chat_rooms WHERE USER_ID = :userId ORDER BY CREATED_AT DESC`,
+        { userId },
+        { outFormat: oracledb.OUT_FORMAT_OBJECT }
+      );
+      return result.rows || [];
+    } finally {
+      await connection.close();
+    }
+  },
+
   // 채팅 메시지 불러오기 (최신순)
-  async getChatMessages(userId: string, limit = 20, cursor?: string) {
+  async getChatMessages(
+    userId: string,
+    roomHash: string,
+    limit = 20,
+    cursor?: string
+  ) {
     if (!userId) {
       throw new Error('사용자 ID가 필요합니다.');
     }
@@ -53,16 +92,23 @@ export const message_query_management = {
       const sql = `
         SELECT ID, USER_ID, DBMS_LOB.SUBSTR(CONTENT, 4000, 1) as CONTENT, CREATED_AT 
         FROM (
-          SELECT * FROM chat_messages 
-          WHERE user_id = :userId 
+          SELECT * FROM chat_messages
+          WHERE user_id = :userId
+          AND room_hash = :roomHash
           ${cursor ? 'AND CREATED_AT < :cursor' : ''}
           ORDER BY created_at DESC
-        ) 
+        )
         WHERE ROWNUM <= :limit
       `;
 
-      const params: { userId: string; limit: number; cursor?: Date } = {
+      const params: {
+        userId: string;
+        roomHash: string;
+        limit: number;
+        cursor?: Date;
+      } = {
         userId,
+        roomHash: roomHash || 'default',
         limit,
       };
       if (cursor) {
@@ -196,7 +242,8 @@ export const message_query_management = {
 
   // 메시지 날짜 목록 조회
   async getMessageDates(
-    userId: string
+    userId: string,
+    roomHash: string
   ): Promise<{ date: string; count: number }[]> {
     const connection = await getOracleConnection();
     try {
@@ -204,15 +251,16 @@ export const message_query_management = {
         SELECT 
           TO_CHAR(CREATED_AT, 'YYYY-MM-DD') as MESSAGE_DATE,
           COUNT(*) as MESSAGE_COUNT
-        FROM chat_messages 
-        WHERE user_id = :userId 
+        FROM chat_messages
+        WHERE user_id = :userId
+        AND room_hash = :roomHash
         GROUP BY TO_CHAR(CREATED_AT, 'YYYY-MM-DD')
         ORDER BY MESSAGE_DATE DESC
       `;
 
       const result = await connection.execute(
         sql,
-        { userId },
+        { userId, roomHash: roomHash || 'default' },
         { outFormat: oracledb.OUT_FORMAT_OBJECT }
       );
 

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -11,6 +11,7 @@ import {
   ServerDetail,
   ServerRes,
   UserListRes,
+  ChatRoomsResponse,
 } from '@/app/types';
 import { ChatResponse } from 'ollama';
 import { SaveServerForm } from '../types/server';
@@ -59,11 +60,13 @@ export const message_management = {
   // 메시지 목록 조회
   getMessages: async (
     userId: string,
+    roomHash: string,
     cursor?: string,
     limit: number = 5
   ): Promise<MessagesResponse> => {
     const queryParams = new URLSearchParams({
       userId,
+      roomHash,
       limit: limit.toString(),
     });
     if (cursor) queryParams.append('cursor', cursor);
@@ -78,10 +81,11 @@ export const message_management = {
 
   // 전체 메시지 날짜 목록 조회
   getAllMessageDates: async (
-    userId: string
+    userId: string,
+    roomHash: string
   ): Promise<{ dates: { date: string; count: number }[] }> => {
     const res = await fetch(
-      `${API_BASE_URL}/message/get-all-dates?userId=${userId}`
+      `${API_BASE_URL}/message/get-all-dates?userId=${userId}&roomHash=${roomHash}`
     );
     if (!res.ok) throw new Error('메시지 날짜 목록 조회 실패');
     return res.json();
@@ -95,6 +99,26 @@ export const message_management = {
       body: JSON.stringify(data),
     });
     if (!res.ok) throw new Error('메시지 저장 실패');
+    return res.json();
+  },
+
+  createRoom: async (
+    userId: string
+  ): Promise<{ roomHash: string }> => {
+    const res = await fetch(`${API_BASE_URL}/message/create-room`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ USER_ID: userId }),
+    });
+    if (!res.ok) throw new Error('채팅방 생성 실패');
+    return res.json();
+  },
+
+  getRooms: async (userId: string): Promise<ChatRoomsResponse> => {
+    const res = await fetch(
+      `${API_BASE_URL}/message/get-rooms?userId=${userId}`
+    );
+    if (!res.ok) throw new Error('채팅방 목록 조회 실패');
     return res.json();
   },
 

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -1,0 +1,9 @@
+export interface ChatRoom {
+  ROOM_HASH: string;
+  USER_ID: string;
+  CREATED_AT: Date;
+}
+
+export interface ChatRoomsResponse {
+  rooms: ChatRoom[];
+}

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -6,3 +6,4 @@ export * from './dashboard';
 export * from './management';
 export * from './server';
 export * from './socket';
+export * from './chat';

--- a/app/types/message.ts
+++ b/app/types/message.ts
@@ -2,6 +2,7 @@
 export interface Message {
   ID?: string | number;
   USER_ID: string;
+  ROOM_HASH?: string;
   CONTENT: string;
   CREATED_AT: Date;
   isUser?: boolean;
@@ -17,6 +18,7 @@ export interface MessagesResponse {
 export interface ChatReq {
   CONTENT: string;
   USER_ID: string;
+  ROOM_HASH?: string;
   ID?: string;
   isMCP?: boolean;
   MCP_SERVER?: string;


### PR DESCRIPTION
## Summary
- support multiple chat rooms with new DB queries
- create API for room creation and listing
- include room hash in message queries and saves
- expose room types and API helpers
- update chat page to load/sent messages per room

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ea2fe418832e91125ccb259b4f9b