### PR TITLE
Implement dark mode with user toggle

### DIFF
--- a/app/(main)/components/Header.tsx
+++ b/app/(main)/components/Header.tsx
@@ -13,7 +13,7 @@ const Header = React.memo(function Header() {
   const [openHover, setOpenHover] = useState(false);
 
   return (
-    <div className="absolute top-0 z-[9999] w-screen border-b bg-gray-50">
+    <div className="absolute top-0 z-[9999] w-screen border-b bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
       <div className="container mx-auto flex h-12 w-full items-center justify-between gap-2 px-4">
         {/* links */}
 

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,14 +1,18 @@
+'use client';
+
 import React from 'react';
 import Header from './components/Header';
 import { ToastContainer } from 'react-toastify';
+import { useThemeStore } from '@/app/store/themeStore';
 
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const theme = useThemeStore((state) => state.theme);
   return (
-    <div className="min-h-screen overflow-y-hidden bg-gray-50">
+    <div className="min-h-screen overflow-y-hidden bg-gray-50 dark:bg-gray-900">
       <Header />
       <div className="pt-12" />
       {children}
@@ -24,7 +28,7 @@ export default function RootLayout({
         pauseOnFocusLoss
         draggable
         pauseOnHover
-        theme="light"
+        theme={theme === 'dark' ? 'dark' : 'light'}
         // transition={Bounce}
       />
     </div>

--- a/app/(main)/settings/components/DarkModeToggle.tsx
+++ b/app/(main)/settings/components/DarkModeToggle.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useThemeStore } from '@/app/store/themeStore';
+
+export default function DarkModeToggle() {
+  const theme = useThemeStore((state) => state.theme);
+  const setTheme = useThemeStore((state) => state.setTheme);
+  const [systemDark, setSystemDark] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    const handle = (e: MediaQueryListEvent) => setSystemDark(e.matches);
+    setSystemDark(mql.matches);
+    mql.addEventListener('change', handle);
+    return () => mql.removeEventListener('change', handle);
+  }, []);
+
+  const isDark = theme === 'dark' || (theme === 'system' && systemDark);
+
+  const toggle = () => {
+    setTheme(isDark ? 'light' : 'dark');
+  };
+
+  return (
+    <label className="inline-flex cursor-pointer items-center gap-2">
+      <input type="checkbox" checked={isDark} onChange={toggle} className="peer sr-only" />
+      <div className="peer relative h-6 w-11 rounded-full bg-gray-200 peer-checked:bg-gray-700 after:absolute after:start-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:after:translate-x-full peer-checked:after:border-white rtl:peer-checked:after:-translate-x-full" />
+      <span className="text-sm select-none">{isDark ? '다크 모드' : '라이트 모드'}</span>
+    </label>
+  );
+}

--- a/app/(main)/settings/page.tsx
+++ b/app/(main)/settings/page.tsx
@@ -5,6 +5,7 @@ import {
   RobotIcon,
 } from '@phosphor-icons/react/ssr';
 import Link from 'next/link';
+import DarkModeToggle from './components/DarkModeToggle';
 
 export default function Setting() {
   const menuList = [
@@ -39,6 +40,9 @@ export default function Setting() {
             <div className="col-span-3 text-xl font-bold">{item.name}</div>
           </Link>
         ))}
+      </div>
+      <div className="mt-8">
+        <DarkModeToggle />
       </div>
     </div>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { Metadata } from 'next';
 import ReactQueryProvider from '@/app/(main)/components/providers/ReactQueryProvider';
 import { NextAuthProvider } from '@/app/providers/NextAuthProvider';
+import ThemeProvider from '@/app/providers/ThemeProvider';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -20,9 +21,11 @@ export default function RootLayout({
         suppressHydrationWarning={process.env.NODE_ENV === 'development'}
         className="antialiased"
       >
-        <NextAuthProvider>
-          <ReactQueryProvider>{children}</ReactQueryProvider>
-        </NextAuthProvider>
+        <ThemeProvider>
+          <NextAuthProvider>
+            <ReactQueryProvider>{children}</ReactQueryProvider>
+          </NextAuthProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/providers/ThemeProvider.tsx
+++ b/app/providers/ThemeProvider.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useThemeStore } from '@/app/store/themeStore';
+
+export default function ThemeProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const theme = useThemeStore((state) => state.theme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const applyTheme = () => {
+      const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const isDark = theme === 'dark' || (theme === 'system' && systemDark);
+      if (isDark) {
+        root.classList.add('dark');
+      } else {
+        root.classList.remove('dark');
+      }
+    };
+
+    applyTheme();
+
+    if (theme === 'system') {
+      const mql = window.matchMedia('(prefers-color-scheme: dark)');
+      mql.addEventListener('change', applyTheme);
+      return () => mql.removeEventListener('change', applyTheme);
+    }
+  }, [theme]);
+
+  return <>{children}</>;
+}

--- a/app/store/themeStore.ts
+++ b/app/store/themeStore.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type Theme = 'light' | 'dark' | 'system';
+
+interface ThemeState {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set) => ({
+      theme: 'system',
+      setTheme: (theme: Theme) => set({ theme }),
+    }),
+    { name: 'theme-storage' }
+  )
+);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 import typography from '@tailwindcss/typography';
 
 export default {
+  darkMode: 'class',
   plugins: [typography],
 };


### PR DESCRIPTION
## Summary
- add Zustand store to persist theme setting
- enable Tailwind dark mode
- update main layouts and header to support dark styling
- provide ThemeProvider to apply theme with system preference
- add DarkModeToggle to settings page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8b695794832e9dca937506734289