### PR TITLE
Improve theme management and default to light mode

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -12,7 +12,7 @@ export default function RootLayout({
 }) {
   const theme = useThemeStore((state) => state.theme);
   return (
-    <div className="min-h-screen overflow-y-hidden bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen overflow-y-hidden bg-background text-foreground">
       <Header />
       <div className="pt-12" />
       {children}

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -14,7 +14,7 @@ export default function Home() {
   }, [session]);
 
   return (
-    <div className="flex h-[calc(100svh-3rem)] w-full justify-center bg-gray-50 dark:bg-gray-900">
+    <div className="flex h-[calc(100svh-3rem)] w-full justify-center bg-background">
       <div className="flex h-full w-full flex-col overflow-y-scroll py-8">
         <h1 className="my-16 text-center text-[8vw] font-black text-gray-900 lg:text-6xl dark:text-gray-100">
           MCP 통합 관리 SYSTEM

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,53 +1,8 @@
 @import 'tailwindcss';
+@import './theme.css';
 
 @theme {
   --color-main: var(--color-gray-800);
-}
-
-/* 다크모드 색상 변수 */
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-  --card: #ffffff;
-  --card-foreground: #171717;
-  --popover: #ffffff;
-  --popover-foreground: #171717;
-  --primary: #171717;
-  --primary-foreground: #fafafa;
-  --secondary: #f5f5f5;
-  --secondary-foreground: #171717;
-  --muted: #f5f5f5;
-  --muted-foreground: #737373;
-  --accent: #f5f5f5;
-  --accent-foreground: #171717;
-  --destructive: #ef4444;
-  --destructive-foreground: #fafafa;
-  --border: #e5e5e5;
-  --input: #e5e5e5;
-  --ring: #171717;
-  --radius: 0.5rem;
-}
-
-.dark {
-  --background: #0a0a0a;
-  --foreground: #ededed;
-  --card: #0a0a0a;
-  --card-foreground: #ededed;
-  --popover: #0a0a0a;
-  --popover-foreground: #ededed;
-  --primary: #ededed;
-  --primary-foreground: #0a0a0a;
-  --secondary: #262626;
-  --secondary-foreground: #ededed;
-  --muted: #262626;
-  --muted-foreground: #a3a3a3;
-  --accent: #262626;
-  --accent-foreground: #ededed;
-  --destructive: #7f1d1d;
-  --destructive-foreground: #ededed;
-  --border: #262626;
-  --input: #262626;
-  --ring: #ededed;
 }
 
 @font-face {

--- a/app/store/themeStore.ts
+++ b/app/store/themeStore.ts
@@ -11,7 +11,8 @@ interface ThemeState {
 export const useThemeStore = create<ThemeState>()(
   persist(
     (set) => ({
-      theme: 'system',
+      // 기본 테마를 라이트 모드로 설정
+      theme: 'light',
       setTheme: (theme: Theme) => set({ theme }),
     }),
     { name: 'theme-storage' }

--- a/app/theme.css
+++ b/app/theme.css
@@ -1,0 +1,44 @@
+:root {
+  --background: #ffffff;
+  --foreground: #171717;
+  --card: #ffffff;
+  --card-foreground: #171717;
+  --popover: #ffffff;
+  --popover-foreground: #171717;
+  --primary: #171717;
+  --primary-foreground: #fafafa;
+  --secondary: #f5f5f5;
+  --secondary-foreground: #171717;
+  --muted: #f5f5f5;
+  --muted-foreground: #737373;
+  --accent: #f5f5f5;
+  --accent-foreground: #171717;
+  --destructive: #ef4444;
+  --destructive-foreground: #fafafa;
+  --border: #e5e5e5;
+  --input: #e5e5e5;
+  --ring: #171717;
+  --radius: 0.5rem;
+}
+
+.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+  --card: #0a0a0a;
+  --card-foreground: #ededed;
+  --popover: #0a0a0a;
+  --popover-foreground: #ededed;
+  --primary: #ededed;
+  --primary-foreground: #0a0a0a;
+  --secondary: #262626;
+  --secondary-foreground: #ededed;
+  --muted: #262626;
+  --muted-foreground: #a3a3a3;
+  --accent: #262626;
+  --accent-foreground: #ededed;
+  --destructive: #7f1d1d;
+  --destructive-foreground: #ededed;
+  --border: #262626;
+  --input: #262626;
+  --ring: #ededed;
+}


### PR DESCRIPTION
## Summary
- centralize theme variables in `app/theme.css`
- import theme variables in `globals.css`
- set default theme to light mode
- use Tailwind theme colors in main layout and page

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f9276f708832eacf80d629b4302bb