### PR TITLE
Unify theme resolution

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -3,14 +3,14 @@
 import React from 'react';
 import Header from './components/Header';
 import { ToastContainer } from 'react-toastify';
-import { useThemeStore } from '@/app/store/themeStore';
+import useResolvedTheme from '@/app/hooks/useResolvedTheme';
 
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const theme = useThemeStore((state) => state.theme);
+  const resolvedTheme = useResolvedTheme();
   return (
     <div className="min-h-screen overflow-y-hidden bg-background text-foreground">
       <Header />
@@ -28,7 +28,7 @@ export default function RootLayout({
         pauseOnFocusLoss
         draggable
         pauseOnHover
-        theme={theme === 'dark' ? 'dark' : 'light'}
+        theme={resolvedTheme === 'dark' ? 'dark' : 'light'}
         // transition={Bounce}
       />
     </div>

--- a/app/(main)/settings/components/DarkModeToggle.tsx
+++ b/app/(main)/settings/components/DarkModeToggle.tsx
@@ -1,22 +1,13 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import useResolvedTheme from '@/app/hooks/useResolvedTheme';
 import { useThemeStore } from '@/app/store/themeStore';
 
 export default function DarkModeToggle() {
-  const theme = useThemeStore((state) => state.theme);
+  const resolvedTheme = useResolvedTheme();
   const setTheme = useThemeStore((state) => state.setTheme);
-  const [systemDark, setSystemDark] = useState(false);
 
-  useEffect(() => {
-    const mql = window.matchMedia('(prefers-color-scheme: dark)');
-    const handle = (e: MediaQueryListEvent) => setSystemDark(e.matches);
-    setSystemDark(mql.matches);
-    mql.addEventListener('change', handle);
-    return () => mql.removeEventListener('change', handle);
-  }, []);
-
-  const isDark = theme === 'dark' || (theme === 'system' && systemDark);
+  const isDark = resolvedTheme === 'dark';
 
   const toggle = () => {
     setTheme(isDark ? 'light' : 'dark');

--- a/app/hooks/useResolvedTheme.ts
+++ b/app/hooks/useResolvedTheme.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { useThemeStore } from '@/app/store/themeStore';
+
+export default function useResolvedTheme() {
+  const theme = useThemeStore((state) => state.theme);
+  const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>('light');
+
+  useEffect(() => {
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    const updateTheme = () => {
+      const systemDark = mql.matches;
+      setResolvedTheme(
+        theme === 'dark' || (theme === 'system' && systemDark) ? 'dark' : 'light'
+      );
+    };
+    updateTheme();
+
+    if (theme === 'system') {
+      mql.addEventListener('change', updateTheme);
+      return () => mql.removeEventListener('change', updateTheme);
+    }
+  }, [theme]);
+
+  return resolvedTheme;
+}

--- a/app/providers/ThemeProvider.tsx
+++ b/app/providers/ThemeProvider.tsx
@@ -1,35 +1,23 @@
 'use client';
 
 import { useEffect } from 'react';
-import { useThemeStore } from '@/app/store/themeStore';
+import useResolvedTheme from '@/app/hooks/useResolvedTheme';
 
 export default function ThemeProvider({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const theme = useThemeStore((state) => state.theme);
+  const resolvedTheme = useResolvedTheme();
 
   useEffect(() => {
     const root = document.documentElement;
-    const applyTheme = () => {
-      const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      const isDark = theme === 'dark' || (theme === 'system' && systemDark);
-      if (isDark) {
-        root.classList.add('dark');
-      } else {
-        root.classList.remove('dark');
-      }
-    };
-
-    applyTheme();
-
-    if (theme === 'system') {
-      const mql = window.matchMedia('(prefers-color-scheme: dark)');
-      mql.addEventListener('change', applyTheme);
-      return () => mql.removeEventListener('change', applyTheme);
+    if (resolvedTheme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
     }
-  }, [theme]);
+  }, [resolvedTheme]);
 
   return <>{children}</>;
 }


### PR DESCRIPTION
## Summary
- centralize theme handling with `useResolvedTheme` hook
- use resolved theme in layout, toggle, and provider

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685faef3e84c832e8389c7f26bd032e7